### PR TITLE
Fix two typos

### DIFF
--- a/_docs/fixture-customization.md
+++ b/_docs/fixture-customization.md
@@ -58,7 +58,7 @@ Composite customizations can also be implemented by inheriting from `CompositeCu
 ```csharp
 class DomainCustomization : CompositeCustomization
 {
-  public DoaminCustomization()
+  public DomainCustomization()
     : base(
         new CustomersCustomization(),
         new AddressCustomization())

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # AutoFixture Documentation
 
-This is the official AutoFixture documentation repository. You can find the deployed versoin of the documentation at [AutoFixture.github.io](https://autofixture.github.io).
+This is the official AutoFixture documentation repository. You can find the deployed version of the documentation at [AutoFixture.github.io](https://autofixture.github.io).
 
 ## Contributing
 


### PR DESCRIPTION
Fixes #29 ("versoin" => "version") and another typo in sample code ("Doamin" => "Domain").